### PR TITLE
feat: manager 接入统一会话鉴权与 RBAC 路由守卫

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@types/node": "^22.10.2",
         "@vitejs/plugin-vue": "^5.2.1",
+        "tailwindcss": "^4.2.1",
         "typescript": "^5.7.2",
         "vite": "^6.0.5",
         "vue-tsc": "^2.2.0"
@@ -1129,6 +1130,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^22.10.2",
     "@vitejs/plugin-vue": "^5.2.1",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.5",
     "vue-tsc": "^2.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1352 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.29(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.29(typescript@5.9.3))
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.2.1(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.13
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.1
+        version: 5.2.4(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.29(typescript@5.9.3))
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.5
+        version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+      vue-tsc:
+        specifier: ^2.2.0
+        version: 2.2.12(typescript@5.9.3)
+
+packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.2.1':
+    resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    resolution: {integrity: sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    resolution: {integrity: sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    resolution: {integrity: sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    resolution: {integrity: sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    resolution: {integrity: sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    resolution: {integrity: sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    resolution: {integrity: sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    resolution: {integrity: sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.1':
+    resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.1':
+    resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.13':
+    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@volar/language-core@2.4.15':
+    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
+
+  '@volar/source-map@2.4.15':
+    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
+
+  '@volar/typescript@2.4.15':
+    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+
+  '@vue/compiler-core@3.5.29':
+    resolution: {integrity: sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==}
+
+  '@vue/compiler-dom@3.5.29':
+    resolution: {integrity: sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==}
+
+  '@vue/compiler-sfc@3.5.29':
+    resolution: {integrity: sha512-oJZhN5XJs35Gzr50E82jg2cYdZQ78wEwvRO6Y63TvLVTc+6xICzJHP1UIecdSPPYIbkautNBanDiWYa64QSFIA==}
+
+  '@vue/compiler-ssr@3.5.29':
+    resolution: {integrity: sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
+  '@vue/language-core@2.2.12':
+    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/reactivity@3.5.29':
+    resolution: {integrity: sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==}
+
+  '@vue/runtime-core@3.5.29':
+    resolution: {integrity: sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==}
+
+  '@vue/runtime-dom@3.5.29':
+    resolution: {integrity: sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==}
+
+  '@vue/server-renderer@3.5.29':
+    resolution: {integrity: sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==}
+    peerDependencies:
+      vue: 3.5.29
+
+  '@vue/shared@3.5.29':
+    resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  enhanced-resolve@5.20.0:
+    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+    engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tailwindcss@4.2.1:
+    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue-tsc@2.2.12:
+    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.29:
+    resolution: {integrity: sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@tailwindcss/node@4.2.1':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.0
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.1
+
+  '@tailwindcss/oxide-android-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.1':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.1':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-arm64': 4.2.1
+      '@tailwindcss/oxide-darwin-x64': 4.2.1
+      '@tailwindcss/oxide-freebsd-x64': 4.2.1
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.1
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.1
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.1
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.1
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
+
+  '@tailwindcss/vite@4.2.1(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@tailwindcss/node': 4.2.1
+      '@tailwindcss/oxide': 4.2.1
+      tailwindcss: 4.2.1
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.13':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@volar/language-core@2.4.15':
+    dependencies:
+      '@volar/source-map': 2.4.15
+
+  '@volar/source-map@2.4.15': {}
+
+  '@volar/typescript@2.4.15':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.29':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/shared': 3.5.29
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.29':
+    dependencies:
+      '@vue/compiler-core': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/compiler-sfc@3.5.29':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/compiler-core': 3.5.29
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-ssr': 3.5.29
+      '@vue/shared': 3.5.29
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.29':
+    dependencies:
+      '@vue/compiler-dom': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
+
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 2.4.15
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.29
+      alien-signals: 1.0.13
+      minimatch: 9.0.9
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@vue/reactivity@3.5.29':
+    dependencies:
+      '@vue/shared': 3.5.29
+
+  '@vue/runtime-core@3.5.29':
+    dependencies:
+      '@vue/reactivity': 3.5.29
+      '@vue/shared': 3.5.29
+
+  '@vue/runtime-dom@3.5.29':
+    dependencies:
+      '@vue/reactivity': 3.5.29
+      '@vue/runtime-core': 3.5.29
+      '@vue/shared': 3.5.29
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.29(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.29
+      '@vue/shared': 3.5.29
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@vue/shared@3.5.29': {}
+
+  alien-signals@1.0.13: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  csstype@3.2.3: {}
+
+  de-indent@1.0.2: {}
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.20.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  entities@7.0.1: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  estree-walker@2.0.2: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  he@1.2.0: {}
+
+  jiti@2.6.1: {}
+
+  lightningcss-android-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.31.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.31.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    optional: true
+
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  muggle-string@0.4.1: {}
+
+  nanoid@3.3.11: {}
+
+  path-browserify@1.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tailwindcss@4.2.1: {}
+
+  tapable@2.3.0: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.13
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+
+  vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.29(typescript@5.9.3)
+
+  vue-tsc@2.2.12(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.15
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
+
+  vue@3.5.29(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.29
+      '@vue/compiler-sfc': 3.5.29
+      '@vue/runtime-dom': 3.5.29
+      '@vue/server-renderer': 3.5.29(vue@3.5.29(typescript@5.9.3))
+      '@vue/shared': 3.5.29
+    optionalDependencies:
+      typescript: 5.9.3

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,105 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import { useSessionStore } from "./stores/session";
+
+interface NavItem {
+  to: string;
+  label: string;
+}
+
+const router = useRouter();
+const session = useSessionStore();
+
+const user = computed(() => session.state.user);
+
+const navItems = computed<NavItem[]>(() => {
+  if (!user.value) {
+    return [];
+  }
+
+  if (user.value.role === "teacher") {
+    return [
+      { to: "/teacher/students", label: "学生列表" },
+      { to: "/teacher/class-overview", label: "班级视图" },
+      { to: "/teacher/dashboard", label: "教师驾驶舱" },
+      { to: "/teacher/activities", label: "教师活动" }
+    ].filter((item) => {
+      if (item.to === "/teacher/students" || item.to === "/teacher/class-overview" || item.to === "/teacher/dashboard") {
+        return session.hasPermission("teacher.students.read");
+      }
+
+      if (item.to === "/teacher/activities") {
+        return session.hasPermission("teacher.activity.execute");
+      }
+
+      return true;
+    });
+  }
+
+  if (user.value.role === "admin") {
+    return [
+      { to: "/admin/org-teachers", label: "组织与账号" },
+      { to: "/admin/authorizations", label: "授权中心" },
+      { to: "/admin/activities-center", label: "活动中心" },
+      { to: "/admin/dashboard-cockpit", label: "管理员驾驶舱" }
+    ].filter((item) => {
+      if (item.to === "/admin/org-teachers") {
+        return session.hasPermission("admin.org.manage");
+      }
+
+      if (item.to === "/admin/authorizations") {
+        return session.hasPermission("admin.authorization.manage");
+      }
+
+      if (item.to === "/admin/activities-center") {
+        return session.hasPermission("admin.activity.publish");
+      }
+
+      if (item.to === "/admin/dashboard-cockpit") {
+        return session.hasPermission("admin.dashboard.read");
+      }
+
+      return true;
+    });
+  }
+
+  return [];
+});
+
+const handleLogout = async () => {
+  await session.logout();
+  await router.replace("/login");
+};
+</script>
+
 <template>
   <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-8">
-    <header class="mb-5 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-      <nav class="mt-3 flex gap-2 text-sm">
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/teacher/students">学生列表</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/teacher/class-overview">班级视图</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/teacher/dashboard">教师驾驶舱</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/teacher/activities">教师活动</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/admin/org-teachers">组织与账号</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/admin/authorizations">授权中心</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/admin/activities-center">活动中心</RouterLink>
-        <RouterLink class="rounded bg-slate-100 px-2 py-1" to="/admin/dashboard-cockpit">管理员驾驶舱</RouterLink>
+    <header v-if="session.state.initialized && user" class="mb-5 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p class="text-xs uppercase tracking-[0.2em] text-slate-500">LESI EDU MANAGER</p>
+          <h1 class="mt-1 text-lg font-bold text-slate-900">管理端 / 教师端</h1>
+        </div>
+        <div class="flex items-center gap-2 text-sm text-slate-600">
+          <span>{{ user.displayName }}（{{ user.role }}）</span>
+          <button class="rounded bg-slate-100 px-2 py-1 text-xs" @click="handleLogout">退出</button>
+        </div>
+      </div>
+
+      <nav class="mt-3 flex flex-wrap gap-2 text-sm">
+        <RouterLink
+          v-for="item in navItems"
+          :key="item.to"
+          class="rounded bg-slate-100 px-2 py-1"
+          :to="item.to"
+        >
+          {{ item.label }}
+        </RouterLink>
       </nav>
-      <p class="text-xs uppercase tracking-[0.2em] text-slate-500">LESI EDU MANAGER</p>
-      <h1 class="mt-1 text-lg font-bold text-slate-900">管理端 / 教师端</h1>
     </header>
 
-    <RouterView />
+    <p v-if="!session.state.initialized" class="mt-16 text-center text-sm text-slate-500">正在恢复登录态...</p>
+    <RouterView v-else />
   </main>
 </template>

--- a/src/constants/rbac.ts
+++ b/src/constants/rbac.ts
@@ -1,0 +1,35 @@
+import type { AuthRole } from "../types/auth";
+
+export const ROLE_PERMISSIONS: Record<AuthRole, string[]> = {
+  student: [
+    "student.profile.read",
+    "student.assessment.submit",
+    "report.read",
+    "task.read",
+    "task.checkin.submit",
+    "certificate.upload"
+  ],
+  teacher: [
+    "teacher.students.read",
+    "teacher.student.detail.read",
+    "teacher.activity.execute",
+    "report.read",
+    "task.read",
+    "student.profile.read"
+  ],
+  admin: [
+    "admin.org.manage",
+    "admin.teacher.manage",
+    "admin.authorization.manage",
+    "admin.activity.publish",
+    "admin.dashboard.read"
+  ]
+};
+
+export const getPermissionsByRole = (role: AuthRole): string[] => {
+  return ROLE_PERMISSIONS[role] ?? [];
+};
+
+export const hasPermissionByRole = (role: AuthRole, permission: string): boolean => {
+  return getPermissionsByRole(role).includes(permission);
+};

--- a/src/pages/AdminActivityCenterPage.vue
+++ b/src/pages/AdminActivityCenterPage.vue
@@ -2,11 +2,8 @@
 import { onMounted, reactive, ref } from "vue";
 import { adminApi, type ActivityItem, type ActivityScopeType, type ActivityType } from "../services/admin";
 import { ApiError } from "../services/http";
-import { useSessionStore } from "../stores/session";
 
 const SNAPSHOT_KEY = "lesi_manager_activities_snapshot";
-
-const session = useSessionStore();
 
 const form = reactive({
   activityType: "course" as ActivityType,
@@ -35,24 +32,15 @@ const parseTimeline = () => {
     .filter((item) => item.key && item.at);
 };
 
-const ensureAdminKey = () => {
-  if (!session.state.adminKey) {
-    feedback.value = "请先输入管理员Key";
-    return false;
-  }
-  return true;
-};
-
 const syncSnapshot = () => {
   localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(activities.value));
 };
 
 const loadActivities = async () => {
-  if (!ensureAdminKey()) return;
   loading.value = true;
   feedback.value = "";
   try {
-    const result = await adminApi.listActivities(session.state.adminKey);
+    const result = await adminApi.listActivities();
     activities.value = result.items;
     syncSnapshot();
   } catch (error) {
@@ -63,7 +51,6 @@ const loadActivities = async () => {
 };
 
 const publish = async () => {
-  if (!ensureAdminKey()) return;
   if (!form.title.trim() || !form.ownerTeacherId.trim() || !form.startAt || !form.endAt || form.scopeTargetId <= 0) {
     feedback.value = "请完整填写活动信息";
     return;
@@ -78,7 +65,7 @@ const publish = async () => {
   if (!confirm("确认发布该活动吗？")) return;
 
   try {
-    await adminApi.publishActivity(session.state.adminKey, {
+    await adminApi.publishActivity({
       activityType: form.activityType,
       title: form.title.trim(),
       scopeType: form.scopeType,
@@ -106,13 +93,6 @@ onMounted(async () => {
   <section class="space-y-5 rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">管理员｜活动中心</h1>
     <p class="text-sm text-slate-600">创建课程/竞赛/项目活动，配置范围和负责人，发布后同步到教师端预览。</p>
-
-    <input
-      :value="session.state.adminKey"
-      @input="session.setAdminKey(($event.target as HTMLInputElement).value)"
-      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
-      placeholder="输入管理员Key"
-    />
 
     <section class="rounded-xl border border-slate-200 p-4">
       <h2 class="text-sm font-semibold">发布活动</h2>

--- a/src/pages/AdminAuthorizationPage.vue
+++ b/src/pages/AdminAuthorizationPage.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from "vue";
+import { computed, reactive, ref } from "vue";
 import { adminApi, type AccessLevel, type AuthorizationGrantPayload, type GrantType } from "../services/admin";
 import { ApiError } from "../services/http";
-import { teacherApi } from "../services/teacher";
-import { useSessionStore } from "../stores/session";
-import type { TeacherStudentItem } from "../types/teacher";
 
 interface ScopeSnapshot extends AuthorizationGrantPayload {
   updatedAt: string;
 }
 
 const STORAGE_KEY = "lesi_manager_scope_snapshot";
-
-const session = useSessionStore();
 
 const form = reactive({
   teacherId: "",
@@ -23,9 +18,6 @@ const form = reactive({
 
 const batchText = ref("class,101,read\nstudent,1001,manage");
 const feedback = ref("");
-const loadingPreview = ref(false);
-const previewTotal = ref(0);
-const previewItems = ref<TeacherStudentItem[]>([]);
 
 const scopes = ref<ScopeSnapshot[]>(readSnapshot());
 
@@ -53,10 +45,6 @@ const teacherScopes = computed(() => {
 });
 
 const ensureReady = () => {
-  if (!session.state.adminKey) {
-    feedback.value = "请先输入管理员Key";
-    return false;
-  }
   if (!form.teacherId.trim()) {
     feedback.value = "请先输入教师ID";
     return false;
@@ -92,26 +80,6 @@ const handleError = (error: unknown) => {
   feedback.value = error instanceof ApiError ? error.message : "操作失败";
 };
 
-const refreshPreview = async () => {
-  if (!form.teacherId.trim()) {
-    previewItems.value = [];
-    previewTotal.value = 0;
-    return;
-  }
-
-  loadingPreview.value = true;
-  try {
-    const result = await teacherApi.getStudents(form.teacherId.trim(), { page: 1, pageSize: 20 });
-    previewItems.value = result.items;
-    previewTotal.value = result.total;
-  } catch {
-    previewItems.value = [];
-    previewTotal.value = 0;
-  } finally {
-    loadingPreview.value = false;
-  }
-};
-
 const submitSingle = async (mode: "assign" | "revoke") => {
   if (!ensureReady()) return;
   if (!Number.isInteger(form.targetId) || form.targetId <= 0) {
@@ -130,16 +98,14 @@ const submitSingle = async (mode: "assign" | "revoke") => {
 
   try {
     if (mode === "assign") {
-      await adminApi.assignGrant(session.state.adminKey, payload);
+      await adminApi.assignGrant(payload);
       upsertSnapshot(payload);
-      feedback.value = "授权已分配，并已实时刷新列表";
+      feedback.value = "授权已分配";
     } else {
-      await adminApi.revokeGrant(session.state.adminKey, payload);
+      await adminApi.revokeGrant(payload);
       removeSnapshot(payload);
-      feedback.value = "授权已撤销，并已实时刷新列表";
+      feedback.value = "授权已撤销";
     }
-
-    await refreshPreview();
   } catch (error) {
     handleError(error);
   }
@@ -177,43 +143,26 @@ const submitBatch = async (mode: "assign" | "revoke") => {
 
   try {
     if (mode === "assign") {
-      await adminApi.assignGrantBatch(session.state.adminKey, grants);
+      await adminApi.assignGrantBatch(grants);
       grants.forEach(upsertSnapshot);
-      feedback.value = `已批量分配 ${grants.length} 条授权，并实时刷新列表`;
+      feedback.value = `已批量分配 ${grants.length} 条授权`;
     } else {
-      await adminApi.revokeGrantBatch(session.state.adminKey, grants);
+      await adminApi.revokeGrantBatch(grants);
       grants.forEach(removeSnapshot);
-      feedback.value = `已批量撤销 ${grants.length} 条授权，并实时刷新列表`;
+      feedback.value = `已批量撤销 ${grants.length} 条授权`;
     }
-
-    await refreshPreview();
   } catch (error) {
     handleError(error);
   }
 };
-
-watch(
-  () => form.teacherId,
-  async () => {
-    await refreshPreview();
-  }
-);
 </script>
 
 <template>
   <section class="space-y-5 rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">管理员｜授权中心</h1>
-    <p class="text-sm text-slate-600">按教师查看授权范围，支持单条/批量分配与撤销，操作后立即刷新。</p>
+    <p class="text-sm text-slate-600">按教师维护授权范围，支持单条/批量分配与撤销。</p>
 
-    <div class="grid gap-2 md:grid-cols-2">
-      <input
-        :value="session.state.adminKey"
-        @input="session.setAdminKey(($event.target as HTMLInputElement).value)"
-        class="rounded-lg border border-slate-300 px-3 py-2 text-sm"
-        placeholder="输入管理员Key"
-      />
-      <input v-model="form.teacherId" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="输入教师ID（如 T-1）" />
-    </div>
+    <input v-model="form.teacherId" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="输入教师ID（如 T-1）" />
 
     <section class="rounded-xl border border-slate-200 p-4">
       <h2 class="text-sm font-semibold">单条授权</h2>
@@ -252,19 +201,6 @@ watch(
         </li>
       </ul>
       <p v-if="!teacherScopes.length" class="mt-2 text-xs text-slate-500">暂无快照（可先执行分配/撤销）。</p>
-    </section>
-
-    <section class="rounded-xl border border-slate-200 p-4">
-      <h2 class="text-sm font-semibold">教师可见学生预览（用于校验授权变更）</h2>
-      <p v-if="loadingPreview" class="mt-2 text-sm text-slate-500">加载中...</p>
-      <template v-else>
-        <p class="mt-2 text-xs text-slate-500">当前总数：{{ previewTotal }}</p>
-        <ul class="mt-2 space-y-1 text-xs">
-          <li v-for="item in previewItems" :key="item.studentId" class="rounded border border-slate-100 px-2 py-1">
-            {{ item.studentNo }}｜{{ item.name }}｜班级 {{ item.classId }}｜{{ item.assessmentDone ? '测评完成' : '测评未完成' }}
-          </li>
-        </ul>
-      </template>
     </section>
 
     <p v-if="feedback" class="text-sm text-brand-700">{{ feedback }}</p>

--- a/src/pages/AdminDashboardPage.vue
+++ b/src/pages/AdminDashboardPage.vue
@@ -2,9 +2,6 @@
 import { reactive, ref, watch } from "vue";
 import { adminApi, type DashboardCockpitResponse, type DashboardDimension } from "../services/admin";
 import { ApiError } from "../services/http";
-import { useSessionStore } from "../stores/session";
-
-const session = useSessionStore();
 
 const filters = reactive({
   dimension: "class" as DashboardDimension,
@@ -27,17 +24,11 @@ const toNumberOrUndefined = (raw: string): number | undefined => {
 };
 
 const load = async () => {
-  if (!session.state.adminKey) {
-    data.value = null;
-    errorText.value = "请先输入管理员Key";
-    return;
-  }
-
   loading.value = true;
   errorText.value = "";
 
   try {
-    data.value = await adminApi.getDashboardCockpit(session.state.adminKey, {
+    data.value = await adminApi.getDashboardCockpit({
       dimension: filters.dimension,
       schoolId: toNumberOrUndefined(filters.schoolId),
       collegeId: toNumberOrUndefined(filters.collegeId),
@@ -55,16 +46,7 @@ const load = async () => {
 };
 
 watch(
-  () => [
-    session.state.adminKey,
-    filters.dimension,
-    filters.schoolId,
-    filters.collegeId,
-    filters.majorId,
-    filters.classId,
-    filters.startDate,
-    filters.endDate
-  ],
+  () => [filters.dimension, filters.schoolId, filters.collegeId, filters.majorId, filters.classId, filters.startDate, filters.endDate],
   async () => {
     await load();
   },
@@ -78,12 +60,6 @@ watch(
     <p class="text-sm text-slate-600">指标卡 + 柱状图 + 堆叠柱 + 30天趋势折线 + 漏斗图，筛选联动刷新。</p>
 
     <div class="grid gap-2 md:grid-cols-4">
-      <input
-        :value="session.state.adminKey"
-        @input="session.setAdminKey(($event.target as HTMLInputElement).value)"
-        class="rounded-lg border border-slate-300 px-3 py-2 text-sm"
-        placeholder="管理员Key"
-      />
       <select v-model="filters.dimension" class="rounded-lg border border-slate-300 px-3 py-2 text-sm">
         <option value="class">class</option>
         <option value="major">major</option>

--- a/src/pages/AdminOrgTeacherPage.vue
+++ b/src/pages/AdminOrgTeacherPage.vue
@@ -2,9 +2,6 @@
 import { reactive, ref } from "vue";
 import { adminApi } from "../services/admin";
 import { ApiError } from "../services/http";
-import { useSessionStore } from "../stores/session";
-
-const session = useSessionStore();
 
 const collegeForm = reactive({ schoolId: 1, name: "" });
 const teacherForm = reactive({ name: "", account: "", password: "", status: "active" as "active" | "frozen" });
@@ -17,18 +14,9 @@ const handleError = (error: unknown) => {
   feedback.value = error instanceof ApiError ? error.message : "操作失败";
 };
 
-const ensureAdminKey = () => {
-  if (!session.state.adminKey) {
-    feedback.value = "请先输入管理员Key";
-    return false;
-  }
-  return true;
-};
-
 const createCollege = async () => {
-  if (!ensureAdminKey()) return;
   try {
-    const created = await adminApi.createCollege(session.state.adminKey, {
+    const created = await adminApi.createCollege({
       schoolId: Number(collegeForm.schoolId),
       name: collegeForm.name
     });
@@ -41,14 +29,13 @@ const createCollege = async () => {
 };
 
 const renameCollege = async (collegeId: number) => {
-  if (!ensureAdminKey()) return;
   const nextName = prompt("请输入新学院名称");
   if (!nextName) return;
 
   if (!confirm(`确认将学院改名为 ${nextName} 吗？`)) return;
 
   try {
-    await adminApi.updateCollege(session.state.adminKey, collegeId, { name: nextName });
+    await adminApi.updateCollege(collegeId, { name: nextName });
     colleges.value = colleges.value.map((item) => (item.collegeId === collegeId ? { ...item, name: nextName } : item));
     feedback.value = "组织树更新成功（已重命名）";
   } catch (error) {
@@ -57,11 +44,10 @@ const renameCollege = async (collegeId: number) => {
 };
 
 const removeCollege = async (collegeId: number) => {
-  if (!ensureAdminKey()) return;
   if (!confirm("确认删除该学院吗？此操作不可恢复。")) return;
 
   try {
-    await adminApi.deleteCollege(session.state.adminKey, collegeId);
+    await adminApi.deleteCollege(collegeId);
     colleges.value = colleges.value.filter((item) => item.collegeId !== collegeId);
     feedback.value = "组织树更新成功（已删除）";
   } catch (error) {
@@ -70,9 +56,8 @@ const removeCollege = async (collegeId: number) => {
 };
 
 const createTeacher = async () => {
-  if (!ensureAdminKey()) return;
   try {
-    const created = await adminApi.createTeacher(session.state.adminKey, teacherForm);
+    const created = await adminApi.createTeacher(teacherForm);
     teachers.value.push({
       teacherId: created.teacherId,
       name: teacherForm.name,
@@ -89,12 +74,11 @@ const createTeacher = async () => {
 };
 
 const toggleTeacherStatus = async (teacherId: string, status: "active" | "frozen") => {
-  if (!ensureAdminKey()) return;
   const nextStatus = status === "active" ? "frozen" : "active";
   if (!confirm(`确认将账号状态改为 ${nextStatus} 吗？`)) return;
 
   try {
-    await adminApi.updateTeacherStatus(session.state.adminKey, teacherId, nextStatus);
+    await adminApi.updateTeacherStatus(teacherId, nextStatus);
     teachers.value = teachers.value.map((item) => (item.teacherId === teacherId ? { ...item, status: nextStatus } : item));
     feedback.value = "教师账号操作已即时生效";
   } catch (error) {
@@ -103,13 +87,12 @@ const toggleTeacherStatus = async (teacherId: string, status: "active" | "frozen
 };
 
 const resetTeacherPassword = async (teacherId: string) => {
-  if (!ensureAdminKey()) return;
   const newPassword = prompt("请输入新密码（至少8位）");
   if (!newPassword) return;
   if (!confirm("确认重置该教师密码吗？")) return;
 
   try {
-    await adminApi.resetTeacherPassword(session.state.adminKey, teacherId, newPassword);
+    await adminApi.resetTeacherPassword(teacherId, newPassword);
     feedback.value = "已完成密码重置";
   } catch (error) {
     handleError(error);
@@ -120,13 +103,6 @@ const resetTeacherPassword = async (teacherId: string) => {
 <template>
   <section class="space-y-5 rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">管理员｜组织与教师账号管理</h1>
-
-    <input
-      :value="session.state.adminKey"
-      @input="session.setAdminKey(($event.target as HTMLInputElement).value)"
-      class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
-      placeholder="输入管理员Key"
-    />
 
     <section class="rounded-xl border border-slate-200 p-4">
       <h2 class="text-sm font-semibold">组织树维护</h2>

--- a/src/pages/ForbiddenPage.vue
+++ b/src/pages/ForbiddenPage.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import { getDefaultRouteByRole, useSessionStore } from "../stores/session";
+
+const router = useRouter();
+const session = useSessionStore();
+
+const goHome = async () => {
+  if (!session.state.user) {
+    await router.replace("/login");
+    return;
+  }
+
+  await router.replace(getDefaultRouteByRole(session.state.user.role));
+};
+</script>
+
+<template>
+  <section class="mx-auto mt-8 max-w-xl rounded-2xl border border-slate-200 bg-white p-6 text-center shadow">
+    <h1 class="text-2xl font-bold text-slate-900">无权限访问</h1>
+    <p class="mt-2 text-sm text-slate-600">当前账号没有该页面访问权限，请联系管理员授权。</p>
+
+    <div class="mt-5 flex justify-center gap-2">
+      <button class="rounded bg-slate-100 px-3 py-1.5 text-sm" @click="goHome">返回首页</button>
+      <button class="rounded bg-brand-500 px-3 py-1.5 text-sm text-white" @click="router.push('/login')">切换账号</button>
+    </div>
+  </section>
+</template>

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { reactive, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { ApiError } from "../services/http";
+import { getDefaultRouteByRole, useSessionStore } from "../stores/session";
+import type { AuthRole } from "../types/auth";
+
+const router = useRouter();
+const route = useRoute();
+const session = useSessionStore();
+
+const form = reactive({
+  account: "",
+  password: ""
+});
+
+const loading = ref(false);
+const errorText = ref("");
+
+const resolveRedirectPath = (role: AuthRole): string => {
+  const rawRedirect = route.query.redirect;
+  if (typeof rawRedirect === "string" && rawRedirect.startsWith("/")) {
+    return rawRedirect;
+  }
+
+  return getDefaultRouteByRole(role);
+};
+
+const submit = async () => {
+  if (!form.account.trim() || !form.password) {
+    errorText.value = "请输入账号和密码";
+    return;
+  }
+
+  loading.value = true;
+  errorText.value = "";
+
+  try {
+    const user = await session.loginByAccount({
+      account: form.account,
+      password: form.password
+    });
+
+    if (!user) {
+      errorText.value = "登录失败，请重试";
+      return;
+    }
+
+    if (user.role === "student") {
+      await session.logout();
+      errorText.value = "学生账号请使用学生端登录";
+      return;
+    }
+
+    await router.replace(resolveRedirectPath(user.role));
+  } catch (error) {
+    errorText.value = error instanceof ApiError ? error.message : "登录失败，请稍后重试";
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<template>
+  <main class="mx-auto flex min-h-screen w-full max-w-md items-center px-6 py-10">
+    <section class="w-full rounded-2xl border border-slate-200 bg-white p-6 shadow">
+      <p class="text-xs uppercase tracking-[0.2em] text-slate-500">LESI EDU MANAGER</p>
+      <h1 class="mt-2 text-2xl font-bold text-slate-900">统一登录</h1>
+      <p class="mt-1 text-sm text-slate-500">管理员 / 教师使用同一入口</p>
+
+      <form class="mt-5 space-y-3" @submit.prevent="submit">
+        <input
+          v-model="form.account"
+          class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+          placeholder="账号"
+          autocomplete="username"
+        />
+        <input
+          v-model="form.password"
+          type="password"
+          class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+          placeholder="密码"
+          autocomplete="current-password"
+        />
+
+        <button
+          :disabled="loading"
+          class="w-full rounded-lg bg-brand-500 px-3 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+          type="submit"
+        >
+          {{ loading ? "登录中..." : "登录" }}
+        </button>
+      </form>
+
+      <p v-if="errorText" class="mt-3 text-sm text-rose-600">{{ errorText }}</p>
+    </section>
+  </main>
+</template>

--- a/src/pages/TeacherActivitiesPage.vue
+++ b/src/pages/TeacherActivitiesPage.vue
@@ -18,7 +18,7 @@ const allActivities = computed<ActivityItem[]>(() => {
 });
 
 const visibleActivities = computed(() => {
-  const teacherId = session.state.teacherId.trim();
+  const teacherId = session.state.user?.teacherId?.trim();
   if (!teacherId) return [];
   return allActivities.value.filter((item) => item.ownerTeacherId === teacherId);
 });
@@ -27,14 +27,7 @@ const visibleActivities = computed(() => {
 <template>
   <section class="rounded-2xl border border-slate-200 bg-white p-6 shadow">
     <h1 class="text-xl font-bold text-slate-900">教师端｜活动可见列表</h1>
-    <p class="mt-2 text-sm text-slate-600">按当前教师ID展示已发布活动（由管理员发布后同步）。</p>
-
-    <input
-      :value="session.state.teacherId"
-      @input="session.setTeacherId(($event.target as HTMLInputElement).value)"
-      class="mt-3 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
-      placeholder="输入教师ID（如 T-1）"
-    />
+    <p class="mt-2 text-sm text-slate-600">按当前登录教师身份展示已发布活动（由管理员发布后同步）。</p>
 
     <ul class="mt-4 space-y-2 text-sm">
       <li v-for="item in visibleActivities" :key="item.activityId" class="rounded border border-slate-100 px-3 py-2">

--- a/src/pages/TeacherClassOverviewPage.vue
+++ b/src/pages/TeacherClassOverviewPage.vue
@@ -3,11 +3,9 @@ import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { ApiError } from "../services/http";
 import { teacherApi } from "../services/teacher";
-import { useSessionStore } from "../stores/session";
 import type { TeacherStudentItem } from "../types/teacher";
 
 const router = useRouter();
-const session = useSessionStore();
 
 const options = reactive({
   thresholdDays: 30,
@@ -18,18 +16,11 @@ const loading = ref(false);
 const errorText = ref("");
 const students = ref<TeacherStudentItem[]>([]);
 
-const hasTeacherId = computed(() => session.state.teacherId.trim().length > 0);
-
 const load = async () => {
-  if (!hasTeacherId.value) {
-    students.value = [];
-    return;
-  }
-
   loading.value = true;
   errorText.value = "";
   try {
-    const result = await teacherApi.getStudents(session.state.teacherId, {
+    const result = await teacherApi.getStudents({
       classId: options.classId ? Number(options.classId) : undefined,
       page: 1,
       pageSize: 100
@@ -37,12 +28,13 @@ const load = async () => {
     students.value = result.items;
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "加载失败";
+    students.value = [];
   } finally {
     loading.value = false;
   }
 };
 
-watch(() => [session.state.teacherId, options.classId], load, { immediate: true });
+watch(() => [options.classId], load, { immediate: true });
 
 const rows = computed(() =>
   students.value.map((item) => ({
@@ -70,19 +62,12 @@ const goDetail = (studentId: number) => router.push(`/teacher/students/${student
     <h1 class="text-xl font-bold text-slate-900">教师端｜班级视图与异常名单</h1>
     <p class="mt-2 text-sm text-slate-600">默认异常阈值 30 天，可配置并查看异常学生名单。</p>
 
-    <div class="mt-4 grid gap-2 md:grid-cols-3">
-      <input
-        :value="session.state.teacherId"
-        @input="session.setTeacherId(($event.target as HTMLInputElement).value)"
-        class="rounded-lg border border-slate-300 px-3 py-2 text-sm"
-        placeholder="教师ID"
-      />
+    <div class="mt-4 grid gap-2 md:grid-cols-2">
       <input v-model="options.classId" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="班级ID(可选)" />
       <input v-model.number="options.thresholdDays" type="number" min="1" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="异常阈值天数" />
     </div>
 
-    <p v-if="!hasTeacherId" class="mt-4 text-sm text-amber-700">请先输入教师ID。</p>
-    <p v-else-if="loading" class="mt-4 text-sm text-slate-500">加载中...</p>
+    <p v-if="loading" class="mt-4 text-sm text-slate-500">加载中...</p>
     <p v-else-if="errorText" class="mt-4 text-sm text-rose-600">{{ errorText }}</p>
 
     <template v-else>

--- a/src/pages/TeacherStudentDetailPage.vue
+++ b/src/pages/TeacherStudentDetailPage.vue
@@ -3,12 +3,10 @@ import { onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { ApiError } from "../services/http";
 import { teacherApi } from "../services/teacher";
-import { useSessionStore } from "../stores/session";
 import type { TeacherStudentDetailResponse } from "../types/teacher";
 
 const route = useRoute();
 const router = useRouter();
-const session = useSessionStore();
 
 const loading = ref(true);
 const errorText = ref("");
@@ -17,14 +15,14 @@ const detail = ref<TeacherStudentDetailResponse | null>(null);
 onMounted(async () => {
   loading.value = true;
   const studentId = Number(route.params.studentId);
-  if (!session.state.teacherId || !Number.isInteger(studentId) || studentId <= 0) {
-    errorText.value = "缺少教师ID或学生ID无效";
+  if (!Number.isInteger(studentId) || studentId <= 0) {
+    errorText.value = "学生ID无效";
     loading.value = false;
     return;
   }
 
   try {
-    detail.value = await teacherApi.getStudentDetail(session.state.teacherId, studentId);
+    detail.value = await teacherApi.getStudentDetail(studentId);
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "详情加载失败";
   } finally {

--- a/src/pages/TeacherStudentsPage.vue
+++ b/src/pages/TeacherStudentsPage.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from "vue";
+import { reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { teacherApi } from "../services/teacher";
 import { ApiError } from "../services/http";
-import { useSessionStore } from "../stores/session";
 import type { TeacherStudentItem } from "../types/teacher";
 
 const router = useRouter();
-const session = useSessionStore();
 
 const filters = reactive({
   classId: "",
@@ -24,19 +22,11 @@ const errorText = ref("");
 const items = ref<TeacherStudentItem[]>([]);
 const total = ref(0);
 
-const hasTeacherId = computed(() => session.state.teacherId.trim().length > 0);
-
 const load = async () => {
-  if (!hasTeacherId.value) {
-    items.value = [];
-    total.value = 0;
-    return;
-  }
-
   loading.value = true;
   errorText.value = "";
   try {
-    const result = await teacherApi.getStudents(session.state.teacherId, {
+    const result = await teacherApi.getStudents({
       classId: filters.classId ? Number(filters.classId) : undefined,
       majorId: filters.majorId ? Number(filters.majorId) : undefined,
       grade: filters.grade ? Number(filters.grade) : undefined,
@@ -50,13 +40,15 @@ const load = async () => {
     total.value = result.total;
   } catch (error) {
     errorText.value = error instanceof ApiError ? error.message : "加载失败";
+    items.value = [];
+    total.value = 0;
   } finally {
     loading.value = false;
   }
 };
 
 watch(
-  () => [session.state.teacherId, filters.classId, filters.majorId, filters.grade, filters.assessmentStatus, filters.reportStatus, filters.page],
+  () => [filters.classId, filters.majorId, filters.grade, filters.assessmentStatus, filters.reportStatus, filters.page],
   async () => {
     await load();
   },
@@ -74,12 +66,6 @@ const goDetail = (studentId: number) => {
     <p class="mt-2 text-sm text-slate-600">按班级/专业/年级/测评状态/报告状态筛选，仅展示有权限学生。</p>
 
     <div class="mt-4 grid gap-2 md:grid-cols-3">
-      <input
-        :value="session.state.teacherId"
-        @input="session.setTeacherId(($event.target as HTMLInputElement).value)"
-        class="rounded-lg border border-slate-300 px-3 py-2 text-sm"
-        placeholder="输入教师ID（如 T-1）"
-      />
       <input v-model="filters.classId" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="班级ID" />
       <input v-model="filters.majorId" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="专业ID" />
       <input v-model="filters.grade" class="rounded-lg border border-slate-300 px-3 py-2 text-sm" placeholder="年级" />
@@ -95,8 +81,7 @@ const goDetail = (studentId: number) => {
       </select>
     </div>
 
-    <p v-if="!hasTeacherId" class="mt-4 text-sm text-amber-700">请先输入教师ID。</p>
-    <p v-else-if="loading" class="mt-4 text-sm text-slate-500">加载中...</p>
+    <p v-if="loading" class="mt-4 text-sm text-slate-500">加载中...</p>
     <p v-else-if="errorText" class="mt-4 text-sm text-rose-600">{{ errorText }}</p>
 
     <div v-else class="mt-5 overflow-x-auto">

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,21 +1,160 @@
 import { createRouter, createWebHistory } from "vue-router";
 import TeacherStudentsPage from "../pages/TeacherStudentsPage.vue";
 import TeacherStudentDetailPage from "../pages/TeacherStudentDetailPage.vue";
+import LoginPage from "../pages/LoginPage.vue";
+import ForbiddenPage from "../pages/ForbiddenPage.vue";
+import { getDefaultRouteByRole, useSessionStore } from "../stores/session";
+import type { AuthRole } from "../types/auth";
+
+declare module "vue-router" {
+  interface RouteMeta {
+    requiresAuth?: boolean;
+    guestOnly?: boolean;
+    roles?: AuthRole[];
+    permissions?: string[];
+  }
+}
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: "/", redirect: "/teacher/students" },
-    { path: "/teacher/students", component: TeacherStudentsPage },
-    { path: "/teacher/class-overview", component: () => import("../pages/TeacherClassOverviewPage.vue") },
-    { path: "/teacher/students/:studentId", component: TeacherStudentDetailPage },
-    { path: "/teacher/dashboard", component: () => import("../pages/TeacherDashboardPage.vue") },
-    { path: "/teacher/activities", component: () => import("../pages/TeacherActivitiesPage.vue") },
-    { path: "/admin/org-teachers", component: () => import("../pages/AdminOrgTeacherPage.vue") },
-    { path: "/admin/authorizations", component: () => import("../pages/AdminAuthorizationPage.vue") },
-    { path: "/admin/activities-center", component: () => import("../pages/AdminActivityCenterPage.vue") },
-    { path: "/admin/dashboard-cockpit", component: () => import("../pages/AdminDashboardPage.vue") }
+    {
+      path: "/",
+      redirect: () => {
+        const session = useSessionStore();
+        return session.state.user ? getDefaultRouteByRole(session.state.user.role) : "/login";
+      }
+    },
+    {
+      path: "/login",
+      name: "login",
+      component: LoginPage,
+      meta: {
+        requiresAuth: false,
+        guestOnly: true
+      }
+    },
+    {
+      path: "/forbidden",
+      name: "forbidden",
+      component: ForbiddenPage,
+      meta: {
+        roles: ["teacher", "admin"]
+      }
+    },
+    {
+      path: "/teacher/students",
+      component: TeacherStudentsPage,
+      meta: {
+        roles: ["teacher"],
+        permissions: ["teacher.students.read"]
+      }
+    },
+    {
+      path: "/teacher/class-overview",
+      component: () => import("../pages/TeacherClassOverviewPage.vue"),
+      meta: {
+        roles: ["teacher"],
+        permissions: ["teacher.students.read"]
+      }
+    },
+    {
+      path: "/teacher/students/:studentId",
+      component: TeacherStudentDetailPage,
+      meta: {
+        roles: ["teacher"],
+        permissions: ["teacher.student.detail.read"]
+      }
+    },
+    {
+      path: "/teacher/dashboard",
+      component: () => import("../pages/TeacherDashboardPage.vue"),
+      meta: {
+        roles: ["teacher"],
+        permissions: ["teacher.students.read"]
+      }
+    },
+    {
+      path: "/teacher/activities",
+      component: () => import("../pages/TeacherActivitiesPage.vue"),
+      meta: {
+        roles: ["teacher"],
+        permissions: ["teacher.activity.execute"]
+      }
+    },
+    {
+      path: "/admin/org-teachers",
+      component: () => import("../pages/AdminOrgTeacherPage.vue"),
+      meta: {
+        roles: ["admin"],
+        permissions: ["admin.org.manage"]
+      }
+    },
+    {
+      path: "/admin/authorizations",
+      component: () => import("../pages/AdminAuthorizationPage.vue"),
+      meta: {
+        roles: ["admin"],
+        permissions: ["admin.authorization.manage"]
+      }
+    },
+    {
+      path: "/admin/activities-center",
+      component: () => import("../pages/AdminActivityCenterPage.vue"),
+      meta: {
+        roles: ["admin"],
+        permissions: ["admin.activity.publish"]
+      }
+    },
+    {
+      path: "/admin/dashboard-cockpit",
+      component: () => import("../pages/AdminDashboardPage.vue"),
+      meta: {
+        roles: ["admin"],
+        permissions: ["admin.dashboard.read"]
+      }
+    },
+    {
+      path: "/:pathMatch(.*)*",
+      redirect: "/"
+    }
   ]
+});
+
+router.beforeEach(async (to) => {
+  const session = useSessionStore();
+
+  if (!session.state.initialized) {
+    await session.initializeSession();
+  }
+
+  if (to.meta.guestOnly && session.isAuthenticated) {
+    return getDefaultRouteByRole(session.state.user!.role);
+  }
+
+  const requiresAuth = to.meta.requiresAuth !== false;
+  if (!requiresAuth) {
+    return true;
+  }
+
+  if (!session.isAuthenticated) {
+    return {
+      path: "/login",
+      query: {
+        redirect: to.fullPath
+      }
+    };
+  }
+
+  if (to.meta.roles && !session.hasRole(to.meta.roles)) {
+    return "/forbidden";
+  }
+
+  if (to.meta.permissions && !session.hasPermissions(to.meta.permissions)) {
+    return "/forbidden";
+  }
+
+  return true;
 });
 
 export default router;

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -48,7 +48,7 @@ export interface DashboardCockpitFilters {
 
 export interface DashboardCockpitResponse {
   dictionaryVersion: string;
-  filters: Record<string, number | undefined>;
+  filters: Record<string, number | string | undefined>;
   overview: {
     activatedStudentsCount: number;
     assessmentCompletionRate: number;
@@ -108,127 +108,106 @@ const toQuery = (filters: DashboardCockpitFilters): string => {
 };
 
 export const adminApi = {
-  createCollege(adminKey: string, payload: { schoolId: number; name: string }) {
+  createCollege(payload: { schoolId: number; name: string }) {
     return requestJson<{ collegeId: number }>("/admin/org/colleges", {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  updateCollege(adminKey: string, collegeId: number, payload: { name: string }) {
+  updateCollege(collegeId: number, payload: { name: string }) {
     return requestJson<{ message: string }>(`/admin/org/colleges/${collegeId}`, {
       method: "PATCH",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  deleteCollege(adminKey: string, collegeId: number) {
+  deleteCollege(collegeId: number) {
     return requestJson<{ message: string }>(`/admin/org/colleges/${collegeId}`, {
-      method: "DELETE",
-      headers: {
-        "x-admin-key": adminKey
-      }
+      method: "DELETE"
     });
   },
-  createTeacher(adminKey: string, payload: { name: string; account: string; password: string; status: "active" | "frozen" }) {
+  createTeacher(payload: { name: string; account: string; password: string; status: "active" | "frozen" }) {
     return requestJson<{ teacherId: string }>("/admin/teachers", {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  updateTeacherStatus(adminKey: string, teacherId: string, status: "active" | "frozen") {
+  updateTeacherStatus(teacherId: string, status: "active" | "frozen") {
     return requestJson<{ message: string }>(`/admin/teachers/${teacherId}/status`, {
       method: "PATCH",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify({ status })
     });
   },
-  resetTeacherPassword(adminKey: string, teacherId: string, newPassword: string) {
+  resetTeacherPassword(teacherId: string, newPassword: string) {
     return requestJson<{ message: string }>(`/admin/teachers/${teacherId}/reset-password`, {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify({ newPassword })
     });
   },
-  assignGrant(adminKey: string, payload: AuthorizationGrantPayload) {
+  assignGrant(payload: AuthorizationGrantPayload) {
     return requestJson<{ message: string }>("/admin/authorizations/grants", {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  revokeGrant(adminKey: string, payload: AuthorizationGrantPayload) {
+  revokeGrant(payload: AuthorizationGrantPayload) {
     return requestJson<{ message: string }>("/admin/authorizations/grants", {
       method: "DELETE",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  assignGrantBatch(adminKey: string, grants: AuthorizationGrantPayload[]) {
+  assignGrantBatch(grants: AuthorizationGrantPayload[]) {
     return requestJson<{ message: string; count: number }>("/admin/authorizations/grants/batch", {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify({ grants })
     });
   },
-  revokeGrantBatch(adminKey: string, grants: AuthorizationGrantPayload[]) {
+  revokeGrantBatch(grants: AuthorizationGrantPayload[]) {
     return requestJson<{ message: string; count: number }>("/admin/authorizations/grants/batch", {
       method: "DELETE",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify({ grants })
     });
   },
-  publishActivity(adminKey: string, payload: PublishActivityPayload) {
+  publishActivity(payload: PublishActivityPayload) {
     return requestJson<{ message: string }>("/admin/activities", {
       method: "POST",
       headers: {
-        "x-admin-key": adminKey,
         "content-type": "application/json"
       },
       body: JSON.stringify(payload)
     });
   },
-  listActivities(adminKey: string) {
-    return requestJson<{ items: ActivityItem[] }>("/admin/activities", {
-      headers: {
-        "x-admin-key": adminKey
-      }
-    });
+  listActivities() {
+    return requestJson<{ items: ActivityItem[] }>("/admin/activities");
   },
-  getDashboardCockpit(adminKey: string, filters: DashboardCockpitFilters) {
+  getDashboardCockpit(filters: DashboardCockpitFilters) {
     const query = toQuery(filters);
-    return requestJson<DashboardCockpitResponse>(`/admin/dashboard/cockpit?${query}`, {
-      headers: {
-        "x-admin-key": adminKey
-      }
-    });
+    return requestJson<DashboardCockpitResponse>(`/admin/dashboard/cockpit?${query}`);
   }
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,46 @@
+import type { AuthUser } from "../types/auth";
+import { requestJson } from "./http";
+
+export interface LoginByAccountInput {
+  account: string;
+  password: string;
+}
+
+export interface AuthTokenResult {
+  accessToken: string;
+  expiresIn: number;
+  user: AuthUser;
+}
+
+export const authApi = {
+  login(input: LoginByAccountInput) {
+    return requestJson<AuthTokenResult>("/auth/login", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(input),
+      auth: false,
+      retryOnAuthFail: false
+    });
+  },
+  refresh() {
+    return requestJson<AuthTokenResult>("/auth/refresh", {
+      method: "POST",
+      auth: false,
+      retryOnAuthFail: false
+    });
+  },
+  logout() {
+    return requestJson<{ message: string }>("/auth/logout", {
+      method: "POST",
+      auth: false,
+      retryOnAuthFail: false
+    });
+  },
+  me() {
+    return requestJson<AuthUser>("/auth/me", {
+      method: "GET"
+    });
+  }
+};

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -11,13 +11,112 @@ export class ApiError extends Error {
   }
 }
 
-export async function requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, init);
+export interface RequestJsonOptions extends RequestInit {
+  auth?: boolean;
+  retryOnAuthFail?: boolean;
+}
+
+let accessToken: string | null = null;
+let refreshAccessTokenHandler: (() => Promise<string | null>) | null = null;
+let unauthorizedHandler: (() => void) | null = null;
+let refreshInFlight: Promise<string | null> | null = null;
+
+export const setAccessToken = (token: string | null) => {
+  accessToken = token && token.trim().length > 0 ? token.trim() : null;
+};
+
+export const getAccessToken = (): string | null => {
+  return accessToken;
+};
+
+export const configureAuthLifecycle = (input: {
+  onRefreshAccessToken?: (() => Promise<string | null>) | null;
+  onUnauthorized?: (() => void) | null;
+}) => {
+  refreshAccessTokenHandler = input.onRefreshAccessToken ?? null;
+  unauthorizedHandler = input.onUnauthorized ?? null;
+};
+
+const parseJsonSafely = (text: string): unknown => {
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const runRefreshTokenFlow = async (): Promise<string | null> => {
+  if (!refreshAccessTokenHandler) {
+    return null;
+  }
+
+  if (!refreshInFlight) {
+    refreshInFlight = refreshAccessTokenHandler()
+      .catch(() => null)
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+
+  return refreshInFlight;
+};
+
+const buildHeaders = ({
+  headers,
+  auth,
+  token
+}: {
+  headers: HeadersInit | undefined;
+  auth: boolean;
+  token: string | null;
+}): Headers => {
+  const resolved = new Headers(headers);
+
+  if (auth && token) {
+    resolved.set("authorization", `Bearer ${token}`);
+  }
+
+  return resolved;
+};
+
+export async function requestJson<T>(path: string, init: RequestJsonOptions = {}): Promise<T> {
+  const { auth = true, retryOnAuthFail = true, headers, ...rest } = init;
+
+  const doFetch = async (tokenForRequest: string | null) => {
+    return fetch(`${API_BASE_URL}${path}`, {
+      ...rest,
+      headers: buildHeaders({ headers, auth, token: tokenForRequest }),
+      credentials: "include"
+    });
+  };
+
+  let response = await doFetch(accessToken);
+
+  if (response.status === 401 && auth && retryOnAuthFail) {
+    const refreshedToken = await runRefreshTokenFlow();
+    if (refreshedToken) {
+      response = await doFetch(refreshedToken);
+    }
+  }
+
   const text = await response.text();
-  const payload = text ? JSON.parse(text) : null;
+  const payload = parseJsonSafely(text);
 
   if (!response.ok) {
-    throw new ApiError((payload as { message?: string } | null)?.message || `请求失败(${response.status})`, response.status, payload);
+    if (response.status === 401 && auth) {
+      unauthorizedHandler?.();
+    }
+
+    const message =
+      typeof payload === "object" && payload !== null && "message" in payload && typeof (payload as { message?: unknown }).message === "string"
+        ? (payload as { message: string }).message
+        : `请求失败(${response.status})`;
+
+    throw new ApiError(message, response.status, payload);
   }
 
   return payload as T;

--- a/src/services/teacher.ts
+++ b/src/services/teacher.ts
@@ -22,19 +22,11 @@ const toQuery = (filters: TeacherStudentsFilters): string => {
 };
 
 export const teacherApi = {
-  getStudents(teacherId: string, filters: TeacherStudentsFilters) {
+  getStudents(filters: TeacherStudentsFilters) {
     const query = toQuery(filters);
-    return requestJson<TeacherStudentsResponse>(`/teacher/my-students${query ? `?${query}` : ""}`, {
-      headers: {
-        "x-teacher-id": teacherId
-      }
-    });
+    return requestJson<TeacherStudentsResponse>(`/teacher/my-students${query ? `?${query}` : ""}`);
   },
-  getStudentDetail(teacherId: string, studentId: number) {
-    return requestJson<TeacherStudentDetailResponse>(`/teacher/students/${studentId}/detail`, {
-      headers: {
-        "x-teacher-id": teacherId
-      }
-    });
+  getStudentDetail(studentId: number) {
+    return requestJson<TeacherStudentDetailResponse>(`/teacher/students/${studentId}/detail`);
   }
 };

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -1,41 +1,135 @@
 import { reactive } from "vue";
-
-const STORAGE_KEY = "lesi_manager_session";
+import { getPermissionsByRole } from "../constants/rbac";
+import { authApi, type AuthTokenResult, type LoginByAccountInput } from "../services/auth";
+import { configureAuthLifecycle, setAccessToken } from "../services/http";
+import type { AuthRole, AuthUser, SessionUser } from "../types/auth";
 
 interface SessionState {
-  teacherId: string;
-  adminKey: string;
+  initialized: boolean;
+  initializing: boolean;
+  accessToken: string;
+  user: SessionUser | null;
 }
 
-const read = (): SessionState => {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return { teacherId: "", adminKey: "" };
+const state = reactive<SessionState>({
+  initialized: false,
+  initializing: false,
+  accessToken: "",
+  user: null
+});
 
+const toSessionUser = (user: AuthUser): SessionUser => ({
+  ...user,
+  permissions: getPermissionsByRole(user.role)
+});
+
+const clearSessionState = () => {
+  state.accessToken = "";
+  state.user = null;
+  setAccessToken(null);
+};
+
+const applyAuthResult = (result: AuthTokenResult) => {
+  const nextToken = result.accessToken.trim();
+  state.accessToken = nextToken;
+  state.user = toSessionUser(result.user);
+  setAccessToken(nextToken);
+};
+
+const fetchCurrentUserInternal = async (): Promise<SessionUser | null> => {
+  if (!state.accessToken) {
+    state.user = null;
+    return null;
+  }
+
+  const current = await authApi.me();
+  state.user = toSessionUser(current);
+  return state.user;
+};
+
+const refreshSession = async (): Promise<string | null> => {
   try {
-    const parsed = JSON.parse(raw) as SessionState;
-    return {
-      teacherId: parsed.teacherId || "",
-      adminKey: parsed.adminKey || ""
-    };
+    const refreshed = await authApi.refresh();
+    applyAuthResult(refreshed);
+    return refreshed.accessToken;
   } catch {
-    return { teacherId: "", adminKey: "" };
+    clearSessionState();
+    return null;
   }
 };
 
-const state = reactive<SessionState>(read());
+configureAuthLifecycle({
+  onRefreshAccessToken: refreshSession,
+  onUnauthorized: () => {
+    clearSessionState();
+  }
+});
 
-const persist = () => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+export const getDefaultRouteByRole = (role: AuthRole): string => {
+  if (role === "admin") {
+    return "/admin/org-teachers";
+  }
+
+  if (role === "teacher") {
+    return "/teacher/students";
+  }
+
+  return "/login";
 };
 
 export const useSessionStore = () => ({
   state,
-  setTeacherId(value: string) {
-    state.teacherId = value.trim();
-    persist();
+  get isAuthenticated() {
+    return Boolean(state.user && state.accessToken);
   },
-  setAdminKey(value: string) {
-    state.adminKey = value.trim();
-    persist();
+  async initializeSession() {
+    if (state.initialized || state.initializing) {
+      return;
+    }
+
+    state.initializing = true;
+    try {
+      await refreshSession();
+
+      if (state.accessToken) {
+        await fetchCurrentUserInternal().catch(() => undefined);
+      }
+    } finally {
+      state.initialized = true;
+      state.initializing = false;
+    }
+  },
+  async loginByAccount(input: LoginByAccountInput) {
+    const result = await authApi.login({
+      account: input.account.trim(),
+      password: input.password
+    });
+
+    applyAuthResult(result);
+    return state.user;
+  },
+  async fetchCurrentUser() {
+    return fetchCurrentUserInternal();
+  },
+  async logout() {
+    try {
+      await authApi.logout();
+    } finally {
+      clearSessionState();
+      state.initialized = true;
+    }
+  },
+  hasRole(roles: AuthRole[]) {
+    return Boolean(state.user && roles.includes(state.user.role));
+  },
+  hasPermission(permission: string) {
+    return Boolean(state.user && state.user.permissions.includes(permission));
+  },
+  hasPermissions(permissions: string[]) {
+    if (!state.user) {
+      return false;
+    }
+
+    return permissions.every((permission) => state.user!.permissions.includes(permission));
   }
 });

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,24 @@
+export type AuthRole = "student" | "teacher" | "admin";
+
+export interface AuthScope {
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+}
+
+export interface AuthUser {
+  userId: string;
+  role: AuthRole;
+  account: string;
+  displayName: string;
+  teacherId?: string;
+  studentId?: number;
+  studentNo?: string;
+  mustChangePassword?: boolean;
+  scope?: AuthScope;
+}
+
+export interface SessionUser extends AuthUser {
+  permissions: string[];
+}


### PR DESCRIPTION
## 背景
- 对齐父任务：Typeve/lesi-edu-platform#69
- 对齐子任务：#19

## 本次改造
- 接入统一会话认证链路：`/auth/login`、`/auth/refresh`、`/auth/logout`、`/auth/me`
- 新增统一 auth store（accessToken + user + permissions）
- HTTP 客户端统一 Bearer 注入，401 自动 refresh 并重试
- 路由守卫接入 role + permission 校验，新增无权限页
- 页面/API 全量移除旧头鉴权依赖（`X-Teacher-Id` / `X-Admin-Key`）

## 影响范围
- `src/services/http.ts`、`src/services/auth.ts`
- `src/stores/session.ts`
- `src/router/index.ts`
- `src/pages/*`（登录与 teacher/admin 页面鉴权调用）

## 验证
- [x] `pnpm check`
- [x] `pnpm build`

Closes #19
